### PR TITLE
cors fix for development mode

### DIFF
--- a/policy-tool-backend/app.py
+++ b/policy-tool-backend/app.py
@@ -73,3 +73,11 @@ def load_ontologies():
             source_uri=rdflib.URIRef(pathlib.Path(file_path).as_uri()))
         client.put_nanopublication(nanopublication)
         logging.info(f"[LOAD] {f.ljust(max_path_len)}")
+
+
+@app.after_request
+def response_handling(response):
+    if CONFIG_NAME == 'development':
+        response.headers['Access-Control-Allow-Origin'] = '*'
+
+    return response


### PR DESCRIPTION
Adds header to response that removes a CORS issue that would occur when running local (non-docker) development servers for both `policy-tool-frontend` and `policy-tool-backend`.

Issue still occurs if running docker container for `policy-tool-backend`, but this fix may cause other problems if applied in that context. 

Issue does not occur when running the docker containers for both servers.